### PR TITLE
Feature modify contact form

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -4,7 +4,6 @@ class Contact < ApplicationRecord
   validates :phone_number, presence: true,
              format: { with: /\A\d{10,11}\z/ }
   validates :email, presence: true, length: { minimum: 6 },
-             uniqueness: true,
              format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i }
   validates :number_of_people,
              format: { with: /\A[0-9]+\z/}

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,6 +13,8 @@ module TcbnEventManagement
 
     config.i18n.default_locale = :ja
 
+    config.time_zone = 'Tokyo'
+
     config.generators do |g|
       g.test_framework :rspec,
                        fixtures: true,


### PR DESCRIPTION
・デフォルトの日時を日本時間に設定
・Contactモデルを修正（同一のメールアドレスが許可されていないため）